### PR TITLE
[AE-1977] JF - Include option to set cookie expiry when running an experiment

### DIFF
--- a/src/Experiment.php
+++ b/src/Experiment.php
@@ -89,8 +89,10 @@ class Experiment {
             $this->storage = $config['storage'];
         } elseif (isset($config['storage'])) {
             throw new InvalidArgumentException('storage needs to be an instance of StorageInterface');
+        } elseif (isset($config['cookieExpiry'])) {
+            $this->storage = new Cookie($config['cookieExpiry']);
         } else {
-            $this->storage = new Cookie($config['cookieExpiry'] ?? null);
+            $this->storage = new Cookie();
         }
 
         if (isset($config['filter']) && $config['filter'] instanceof FilterInterface) {

--- a/src/Experiment.php
+++ b/src/Experiment.php
@@ -90,7 +90,7 @@ class Experiment {
         } elseif (isset($config['storage'])) {
             throw new InvalidArgumentException('storage needs to be an instance of StorageInterface');
         } else {
-            $this->storage = new Cookie();
+            $this->storage = new Cookie($config['cookieExpiry'] ?? null);
         }
 
         if (isset($config['filter']) && $config['filter'] instanceof FilterInterface) {
@@ -116,11 +116,10 @@ class Experiment {
      * Forces the activation of the given variation name.
      *
      * @param string $variationName
-     * @param integer $cookieExpiry When the cookie should expire (in seconds), defaults to 2 years
      */
-    public function forceVariationName($variationName, $cookieExpiry = 63072000)
+    public function forceVariationName($variationName)
     {
-        $this->storage->set('experiment', $this->name, $variationName, $cookieExpiry);
+        $this->storage->set('experiment', $this->name, $variationName);
     }
 
     /**
@@ -143,11 +142,9 @@ class Experiment {
      * will be randomly chosen unless it was forced by {@link forceVariationName()}. On all subsequent requests
      * it will reuse the variation that was activated on the first request.
      *
-     * @param integer $cookieExpiry When the cookie should expire (in seconds), defaults to 2 years
-     *
      * @return VariationInterface|null
      */
-    public function getActivatedVariation($cookieExpiry = 63072000)
+    public function getActivatedVariation()
     {
         if (!$this->filter->shouldTrigger()) {
             return self::DO_NOT_TRIGGER;
@@ -162,7 +159,7 @@ class Experiment {
         $variation = $this->variations->selectRandomVariation();
 
         if ($variation) {
-            $this->forceVariationName($variation->getName(), $cookieExpiry);
+            $this->forceVariationName($variation->getName());
 
             return $variation;
         }

--- a/src/Experiment.php
+++ b/src/Experiment.php
@@ -116,10 +116,11 @@ class Experiment {
      * Forces the activation of the given variation name.
      *
      * @param string $variationName
+     * @param integer $cookieExpiry When the cookie should expire (in seconds), defaults to 2 years
      */
-    public function forceVariationName($variationName)
+    public function forceVariationName($variationName, $cookieExpiry = 63072000)
     {
-        $this->storage->set('experiment', $this->name, $variationName);
+        $this->storage->set('experiment', $this->name, $variationName, $cookieExpiry);
     }
 
     /**
@@ -142,9 +143,11 @@ class Experiment {
      * will be randomly chosen unless it was forced by {@link forceVariationName()}. On all subsequent requests
      * it will reuse the variation that was activated on the first request.
      *
+     * @param integer $cookieExpiry When the cookie should expire (in seconds), defaults to 2 years
+     *
      * @return VariationInterface|null
      */
-    public function getActivatedVariation()
+    public function getActivatedVariation($cookieExpiry = 63072000)
     {
         if (!$this->filter->shouldTrigger()) {
             return self::DO_NOT_TRIGGER;
@@ -159,7 +162,7 @@ class Experiment {
         $variation = $this->variations->selectRandomVariation();
 
         if ($variation) {
-            $this->forceVariationName($variation->getName());
+            $this->forceVariationName($variation->getName(), $cookieExpiry);
 
             return $variation;
         }

--- a/src/Storage/Cookie.php
+++ b/src/Storage/Cookie.php
@@ -55,7 +55,10 @@ class Cookie implements StorageInterface {
         if (!headers_sent()) {
             // we do not throw an exception for now when headers already sent to not break the application
             // but could do later to make users aware there is an error
-            setcookie($name, $value, time() + $this->cookieExpiry, $path = '/', "", false, $httpOnly = true);
+            // 0 = expire after session
+            // negative value = force expiration
+            $expireTime = $this->cookieExpiry == 0 ? 0 : time() + $this->cookieExpiry;
+            setcookie($name, $value, $expireTime, $path = '/', "", false, $httpOnly = true);
         }
     }
 

--- a/src/Storage/Cookie.php
+++ b/src/Storage/Cookie.php
@@ -19,6 +19,21 @@ class Cookie implements StorageInterface {
      */
     private static $data = [];
 
+    /**
+     * When the cookie should expire (in seconds), defaults to 2 years
+     * @var integer
+     */
+    private $cookieExpiry = 63072000;
+
+    /**
+     * Constructor
+     * @param integer $expiry When the cookie should expire (in seconds), defaults to 2 years
+     */
+    public function __construct($cookieExpiry = 63072000)
+    {
+        $this->cookieExpiry = $cookieExpiry;
+    }
+
     public function get($namespace, $key)
     {
         $name = $this->toName($namespace, $key);
@@ -32,15 +47,7 @@ class Cookie implements StorageInterface {
         }
     }
 
-    /**
-     * Sets the cookie used for our experiment, with the specified value
-     *
-     * @param string $namespace First half of the cookie name
-     * @param string $key Second half of the cookie name
-     * @param string $value Value we intend to set in the cookie
-     * @param integer $expiry When the cookie should expire (in seconds), defaults to 2 years
-     */
-    public function set($namespace, $key, $value, $expiry = 63072000)
+    public function set($namespace, $key, $value)
     {
         $name = $this->toName($namespace, $key);
         self::$data[$name] = $value;
@@ -48,7 +55,7 @@ class Cookie implements StorageInterface {
         if (!headers_sent()) {
             // we do not throw an exception for now when headers already sent to not break the application
             // but could do later to make users aware there is an error
-            setcookie($name, $value, time() + $expiry, $path = '/', "", false, $httpOnly = true);
+            setcookie($name, $value, time() + $this->cookieExpiry, $path = '/', "", false, $httpOnly = true);
         }
     }
 

--- a/src/Storage/Cookie.php
+++ b/src/Storage/Cookie.php
@@ -32,7 +32,15 @@ class Cookie implements StorageInterface {
         }
     }
 
-    public function set($namespace, $key, $value)
+    /**
+     * Sets the cookie used for our experiment, with the specified value
+     *
+     * @param string $namespace First half of the cookie name
+     * @param string $key Second half of the cookie name
+     * @param string $value Value we intend to set in the cookie
+     * @param integer $expiry When the cookie should expire (in seconds), defaults to 2 years
+     */
+    public function set($namespace, $key, $value, $expiry = 63072000)
     {
         $name = $this->toName($namespace, $key);
         self::$data[$name] = $value;
@@ -40,7 +48,7 @@ class Cookie implements StorageInterface {
         if (!headers_sent()) {
             // we do not throw an exception for now when headers already sent to not break the application
             // but could do later to make users aware there is an error
-            setcookie($name, $value, time() + (86400 * 365 * 2), $path = '/', "", false, $httpOnly = true);
+            setcookie($name, $value, time() + $expiry, $path = '/', "", false, $httpOnly = true);
         }
     }
 

--- a/src/Storage/StorageInterface.php
+++ b/src/Storage/StorageInterface.php
@@ -22,6 +22,6 @@ interface StorageInterface {
      * @param string $key
      * @param string|int $value
      */
-    public function set($namespace, $key, $value);
+    public function set($namespace, $key, $value, $expiry = null);
 
 }

--- a/src/Storage/StorageInterface.php
+++ b/src/Storage/StorageInterface.php
@@ -22,6 +22,6 @@ interface StorageInterface {
      * @param string $key
      * @param string|int $value
      */
-    public function set($namespace, $key, $value, $expiry = null);
+    public function set($namespace, $key, $value);
 
 }


### PR DESCRIPTION
### Pre flight checks
❌ My PR isn't ready for automation tests, and I have not added the appropriate labels for it
❌ I haven't tested my change with the Feature Flag off and on
❌ I haven't added test coverage

### General Description ("How did you implement this ticket? Why? Call out any known issues or considerations")
In this PR, we enable the feature of setting an expiry date for the PHP experiment cookie. This PR should be reviewed in tandem with [this PR from California](https://github.com/verticalscope/california/pull/5023).

### Areas Affected
PHP Experiments
